### PR TITLE
Fix HTML for spec-prod

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -17,7 +17,7 @@
         edDraftURI:           "https://w3c.github.io/sparql-results-json/spec/",
         testSuiteURI:         "https://w3c.github.io/rdf-tests/",
         shortName:            "sparql12-results-json",
-        copyrightStart:       "2008",
+        copyrightStart:       "2012",
          
         github:               "https://github.com/w3c/sparql-results-json",
         wgPublicList:         "public-rdf-star-wg",
@@ -32,7 +32,9 @@
         previousMaturity:     "REC",
         
          editors: [
-           { name: "RDF Star Working Group" }
+           { name: "Andy Seaborne", w3cid: "29909"},
+           { name: "Ruben Taelman", w3cid: "84199"},
+           { name: "Gregory Williams", w3cid: "38870"}
          ],
         formerEditors: [
           { name: "Andy Seaborne" },
@@ -47,7 +49,7 @@
       };
     </script>
 
-    <style type="text/css">
+    <style>
       @import url("local.css");
 
       /* ReSpec */
@@ -104,10 +106,7 @@
       </p>
     </section>
 
-    <!--
-        @@ Includes too much - all RDF documents.
-    <section id="related" data-include="./common/related.html"></section>
-    -->
+    <section id="related" data-include="common/sparql-related.html"></section>
 
     <section id="sparql12-documents" class="introductory">
       <h2>SPARQL 1.2 Documents</h2>
@@ -241,7 +240,7 @@
           <h4>Encoding RDF terms</h4>
           <p>An RDF term (IRI, literal or blank node) is encoded as a JSON object. All aspects of the RDF term are represented. The JSON object has a <code>"type"</code> member and other members
           depending on the specific kind of RDF term.</p>
-          <table style="border-collapse: collapse; border-color: #000000" cellpadding="5" border="1">
+          <table style="border-collapse: collapse; border-color: #000000; border-spacing: 5px; border-width: 1px">
             <tbody>
               <tr>
                 <th>RDF Term</th>


### PR DESCRIPTION
Fix HTML.
Add editors.

***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-json/pull/6.html" title="Last updated on Feb 9, 2023, 11:19 PM UTC (2002bb7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-json/6/1cb25a7...2002bb7.html" title="Last updated on Feb 9, 2023, 11:19 PM UTC (2002bb7)">Diff</a>


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-json/pull/6.html" title="Last updated on Feb 10, 2023, 11:00 AM UTC (bcf4210)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-json/6/1cb25a7...bcf4210.html" title="Last updated on Feb 10, 2023, 11:00 AM UTC (bcf4210)">Diff</a>