### PR TITLE
Fix errata-json-results-2

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -292,7 +292,7 @@
     <section id="example">
       <h2>Example</h2>
       <p>This section is not normative.</p>
-      <p>The following JSON is a serialization of the XML document <a class="reference" href="http://www.w3.org/TR/rdf-sparql-XMLres/output.srx">output.srx</a>:</p>
+      <p>The following JSON is a serialization of the XML document <a class="reference" href="https://www.w3.org/2009/sparql/xml-results/output.srx">output.srx</a>:</p>
       <pre class="json">{
    "head": {
        "link": [


### PR DESCRIPTION
I'm not very certain about this one.

It depends on an `srx` file to be published in the 2009 version of the SPARQL/XML spec.
Do we want to leave it as-is, or do we want to publish this `srx` file together with the new 1.2 SPARQL/XML spec, and refer to that one?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-json/pull/8.html" title="Last updated on Feb 17, 2023, 10:59 AM UTC (40140d7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-json/8/fe78a66...40140d7.html" title="Last updated on Feb 17, 2023, 10:59 AM UTC (40140d7)">Diff</a>