### PR TITLE
Allow quoted triples to be expressed

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -462,15 +462,15 @@ span.cancast:hover { background-color: #ffa;
           <p>A variable does not appear in an array element if it is not bound in that particular query solution.</p>
           <p>The order of elements in the bindings array reflects the order, if any, of the query solution sequence.</p>
           <pre class="json">"bindings" : [
-               {
-                 "a" : { ... } ,
-                 "b" : { ... } 
-               } ,
-               {
-                 "a" : { ... } ,
-                 "b" : { ... } 
-               }
-             ]</pre>
+  {
+    "a" : { ... } ,
+    "b" : { ... } 
+  } ,
+  {
+    "a" : { ... } ,
+    "b" : { ... } 
+  }
+]</pre>
           <p>If the query returns no solutions, an empty array is used.</p>
           <pre class="json">"bindings" : []</pre>
         </section>
@@ -538,121 +538,87 @@ span.cancast:hover { background-color: #ffa;
       <section id="example-bindings">
         <h2>Variable Binding Results Examples</h2>
         <p>The following JSON is a serialization of the XML document <a class="reference" href="https://www.w3.org/2009/sparql/xml-results/output.srx">output.srx</a>:</p>
-        <pre class="json">{
-   "head": {
-       "link": [
-           "http://www.w3.org/TR/rdf-sparql-XMLres/example.rq"
-           ],
-       "vars": [
-           "x",
-           "hpage",
-           "name",
-           "mbox",
-           "age",
-           "blurb",
-           "friend"
-           ]
-       },
-   "results": {
-       "bindings": [
-               {
-                   "x" : { "type": "bnode", "value": "r1" },
+        <pre class="json">
 
-                   "hpage" : { "type": "uri", "value": "http://work.example.org/alice/" },
-
-                   "name" : {  "type": "literal", "value": "Alice" } ,
-                   
-                   "mbox" : {  "type": "literal", "value": "" } ,
-
-                   "blurb" : {
-                     "datatype": "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral",
-                     "type": "literal",
-                     "value": "&lt;p xmlns=\"http://www.w3.org/1999/xhtml\"&gt;My name is &lt;b&gt;alice&lt;/b&gt;&lt;/p&gt;"
-                   },
-
-                   "friend" : { "type": "bnode", "value": "r2" }
-               },
-               {
-                   "x" : { "type": "bnode", "value": "r2" },
-                   
-                   "hpage" : { "type": "uri", "value": "http://work.example.org/bob/" },
-                   
-                   "name" : { "type": "literal", "value": "Bob", "xml:lang": "en" },
-
-                   "mbox" : { "type": "uri", "value": "mailto:bob@work.example.org" },
-
-                   "friend" : { "type": "bnode", "value": "r1" }
-               }
-           ]
-       }
-}</pre>
+{
+  "head": {
+    "link": [ "http://www.w3.org/TR/rdf-sparql-XMLres/example.rq" ],
+    "vars": [
+      "x",
+      "hpage",
+      "name",
+      "mbox",
+      "age",
+      "blurb",
+      "friend"
+    ]
+  },
+  "results": {
+    "bindings": [
+      {
+        "x":     { "type": "bnode",   "value": "r1" },
+        "hpage": { "type": "uri",     "value": "http://work.example.org/alice/" },
+        "name":  { "type": "literal", "value": "Alice" },
+        "mbox":  { "type": "literal", "value": "" },
+        "blurb": {
+          "datatype": "http://www.w3.org/1999/02/22-rdf-syntax-ns#XMLLiteral",
+          "type": "literal",
+          "value": "&lt;p xmlns=\"http://www.w3.org/1999/xhtml\"&gt;My name is &lt;b&gt;alice&lt;/b&gt;&lt;/p&gt;"
+        },
+        "friend": { "type": "bnode", "value": "r2" }
+      },
+      {
+        "x":      { "type": "bnode",   "value": "r2" },
+        "hpage":  { "type": "uri",     "value": "http://work.example.org/bob/" },
+        "name":   { "type": "literal", "value": "Bob", "xml:lang": "en" },
+        "mbox":   { "type": "uri",     "value": "mailto:bob@work.example.org" },
+        "friend": { "type": "bnode",   "value": "r1" }
+      }
+    ]
+  }
+}
+</pre>
       </section>
       <section id="example-bindings-quoted">
         <h2>Variable Binding Results Examples with Quoted Triples</h2>
         <p>The following JSON is a serialization of the XML document <a class="reference" href="https://www.w3.org/2009/sparql/xml-results/output-quoted.srx">output-quoted.srx</a> that contains quoted triples:</p>
         <pre class="json">{
-   "head": {
-       "link": [
-           "http://www.w3.org/TR/rdf-sparql-XMLres/example-quoted.rq"
-           ],
-       "vars": [
-           "x",
-           "name",
-           "quoted"
-           ]
-       },
-   "results": {
-       "bindings": [
-               {
-                   "x" : { "type": "bnode", "value": "r1" },
-
-                   "name" : {  "type": "literal", "value": "Alice" } ,
-
-                   "quoted" : {
-                     "type": "triple",
-                     "value": {
-                        "subject": {
-                           "type": "uri",
-                           "value": "http://example.org/alice"
-                        },
-                        "predicate": {
-                           "type": "uri",
-                           "value": "http://example.org/name"
-                        },
-                        "object": {
-                           "type": "literal",
-                           "value": "Alice",
-                           "datatype": "http://www.w3.org/2001/XMLSchema#string"
-                        }
-                     }
-                   }
-               },
-               {
-                   "x" : { "type": "bnode", "value": "r2" },
-                   
-                   "name" : { "type": "literal", "value": "Bob", "xml:lang": "en" },
-
-                   "quoted" : {
-                     "type": "triple",
-                     "value": {
-                        "subject": {
-                           "type": "uri",
-                           "value": "http://example.org/bob"
-                        },
-                        "predicate": {
-                           "type": "uri",
-                           "value": "http://example.org/name"
-                        },
-                        "object": {
-                           "type": "literal",
-                           "value": "Bob",
-                           "datatype": "http://www.w3.org/2001/XMLSchema#string"
-                        }
-                     }
-                   }
-               }
-           ]
-       }
+  "head": {
+    "link": [ "http://www.w3.org/TR/rdf-sparql-XMLres/example-quoted.rq" ],
+    "vars": [
+      "x",
+      "name",
+      "quoted"
+    ]
+  },
+  "results": {
+    "bindings": [
+      {
+        "x":    { "type": "bnode",   "value": "r1" },
+        "name": { "type": "literal", "value": "Alice" },
+        "quoted": {
+          "type": "triple",
+          "value": {
+            "subject":   { "type": "uri",     "value": "http://example.org/alice" },
+            "predicate": { "type": "uri",     "value": "http://example.org/name" },
+            "object":    { "type": "literal", "value": "Alice", "datatype": "http://www.w3.org/2001/XMLSchema#string" }
+          }
+        }
+      },
+      {
+        "x":    { "type": "bnode",   "value": "r2" },
+        "name": { "type": "literal", "value": "Bob", "xml:lang": "en" },
+        "quoted": {
+          "type": "triple",
+          "value": {
+            "subject":   { "type": "uri",     "value": "http://example.org/bob" },
+            "predicate": { "type": "uri",     "value": "http://example.org/name" },
+            "object":    { "type": "literal", "value": "Bob", "datatype": "http://www.w3.org/2001/XMLSchema#string" }
+          }
+        }
+      }
+    ]
+  }
 }</pre>
       </section>
     </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -370,7 +370,7 @@ span.cancast:hover { background-color: #ffa;
       <p>This document describes how to serialize SPARQL results (SELECT and ASK query forms) in a <a data-cite="rfc4627#">JSON</a> format. The format is designed to be a
       complete representation of the information in the query results. The results of a SELECT query are serilialized as an array, where each array element is one "row" of the query results; the
       results of an ASK query give the boolean value of the query result.</p>
-      <p>An Internet Media Type is provied for <code>application/sparql-results+json</code>.</p>
+      <p>An Internet Media Type is provided for <code>application/sparql-results+json</code>.</p>
       <p>There is also a [[[SPARQL12-RESULTS-XML]]] which follows a similar design pattern but uses XML as the
       serialization.</p>
       <p>Unless otherwise noted in the section heading, all sections and appendices in this document are normative.</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -476,7 +476,7 @@ span.cancast:hover { background-color: #ffa;
         </section>
         <section id="select-encode-terms">
           <h4>Encoding RDF terms</h4>
-          <p>An RDF term (IRI, literal or blank node) is encoded as a JSON object. All aspects of the RDF term are represented. The JSON object has a <code>"type"</code> member and other members
+          <p>An RDF term (IRI, literal, blank node, or quoted triple) is encoded as a JSON object. All aspects of the RDF term are represented. The JSON object has a <code>"type"</code> member and other members
           depending on the specific kind of RDF term.</p>
           <table style="border-collapse: collapse; border-color: #000000; border-spacing: 5px; border-width: 1px">
             <tbody>
@@ -504,10 +504,15 @@ span.cancast:hover { background-color: #ffa;
                 <td>Blank node, label <em><b>B</b></em></td>
                 <td><code>{"type": "bnode", "value": "<em><b>B</b></em>"}</code></td>
               </tr>
+              <tr>
+                <td>Quoted triple, with subject <em><b>S</b></em>, predicate <em><b>P</b></em>, and object <em><b>O</b></em></td>
+                <td><code>{"type": "triple", "subject": "<em><b>S</b></em>", "predicate": "<em><b>P</b></em>", "object": "<em><b>O</b></em>"}</code></td>
+              </tr>
             </tbody>
           </table>
           <p>The blank node label is scoped to the results object. That is, two blank nodes with the same label in a single SPARQL Results JSON object are the same blank node. This is not an
           indication of any internal system identifier the SPARQL processor may use. Use of the same label in another SPARQL Results JSON object does not imply it is the same blank node.</p>
+          <p>The subject, predicate, and object of a quoted triple are encoded using the same format, recursively.</p>
         </section>
       </section>
     </section>
@@ -543,7 +548,8 @@ span.cancast:hover { background-color: #ffa;
            "mbox",
            "age",
            "blurb",
-           "friend"
+           "friend",
+           "quoted"
            ]
        },
    "results": {
@@ -563,7 +569,26 @@ span.cancast:hover { background-color: #ffa;
                      "value": "&lt;p xmlns=\"http://www.w3.org/1999/xhtml\"&gt;My name is &lt;b&gt;alice&lt;/b&gt;&lt;/p&gt;"
                    },
 
-                   "friend" : { "type": "bnode", "value": "r2" }
+                   "friend" : { "type": "bnode", "value": "r2" },
+
+                   "quoted" : {
+                     "type": "triple",
+                     "value": {
+                        "subject": {
+                           "type": "uri",
+                           "value" "http://example.org/alice"
+                        },
+                        "predicate": {
+                           "type": "uri",
+                           "value" "http://example.org/name"
+                        },
+                        "object": {
+                           "type": "literal",
+                           "value" "Alice",
+                           "datatype": "http://www.w3.org/2001/XMLSchema#string"
+                        }
+                     }
+                   }
                },
                {
                    "x" : { "type": "bnode", "value": "r2" },
@@ -574,7 +599,26 @@ span.cancast:hover { background-color: #ffa;
 
                    "mbox" : { "type": "uri", "value": "mailto:bob@work.example.org" },
 
-                   "friend" : { "type": "bnode", "value": "r1" }
+                   "friend" : { "type": "bnode", "value": "r1" },
+
+                   "quoted" : {
+                     "type": "triple",
+                     "value": {
+                        "subject": {
+                           "type": "uri",
+                           "value" "http://example.org/bob"
+                        },
+                        "predicate": {
+                           "type": "uri",
+                           "value" "http://example.org/name"
+                        },
+                        "object": {
+                           "type": "literal",
+                           "value" "Bob",
+                           "datatype": "http://www.w3.org/2001/XMLSchema#string"
+                        }
+                     }
+                   }
                }
            ]
        }

--- a/spec/index.html
+++ b/spec/index.html
@@ -533,10 +533,12 @@ span.cancast:hover { background-color: #ffa;
       </section>
     </section>
     <section id="example">
-      <h2>Example</h2>
+      <h2>Examples</h2>
       <p>This section is not normative.</p>
-      <p>The following JSON is a serialization of the XML document <a class="reference" href="https://www.w3.org/2009/sparql/xml-results/output.srx">output.srx</a>:</p>
-      <pre class="json">{
+      <section id="example-bindings">
+        <h2>Variable Binding Results Examples</h2>
+        <p>The following JSON is a serialization of the XML document <a class="reference" href="https://www.w3.org/2009/sparql/xml-results/output.srx">output.srx</a>:</p>
+        <pre class="json">{
    "head": {
        "link": [
            "http://www.w3.org/TR/rdf-sparql-XMLres/example.rq"
@@ -548,8 +550,7 @@ span.cancast:hover { background-color: #ffa;
            "mbox",
            "age",
            "blurb",
-           "friend",
-           "quoted"
+           "friend"
            ]
        },
    "results": {
@@ -569,26 +570,7 @@ span.cancast:hover { background-color: #ffa;
                      "value": "&lt;p xmlns=\"http://www.w3.org/1999/xhtml\"&gt;My name is &lt;b&gt;alice&lt;/b&gt;&lt;/p&gt;"
                    },
 
-                   "friend" : { "type": "bnode", "value": "r2" },
-
-                   "quoted" : {
-                     "type": "triple",
-                     "value": {
-                        "subject": {
-                           "type": "uri",
-                           "value" "http://example.org/alice"
-                        },
-                        "predicate": {
-                           "type": "uri",
-                           "value" "http://example.org/name"
-                        },
-                        "object": {
-                           "type": "literal",
-                           "value" "Alice",
-                           "datatype": "http://www.w3.org/2001/XMLSchema#string"
-                        }
-                     }
-                   }
+                   "friend" : { "type": "bnode", "value": "r2" }
                },
                {
                    "x" : { "type": "bnode", "value": "r2" },
@@ -599,22 +581,71 @@ span.cancast:hover { background-color: #ffa;
 
                    "mbox" : { "type": "uri", "value": "mailto:bob@work.example.org" },
 
-                   "friend" : { "type": "bnode", "value": "r1" },
+                   "friend" : { "type": "bnode", "value": "r1" }
+               }
+           ]
+       }
+}</pre>
+      </section>
+      <section id="example-bindings-quoted">
+        <h2>Variable Binding Results Examples with Quoted Triples</h2>
+        <p>The following JSON is a serialization of the XML document <a class="reference" href="https://www.w3.org/2009/sparql/xml-results/output-quoted.srx">output-quoted.srx</a> that contains quoted triples:</p>
+        <pre class="json">{
+   "head": {
+       "link": [
+           "http://www.w3.org/TR/rdf-sparql-XMLres/example-quoted.rq"
+           ],
+       "vars": [
+           "x",
+           "name",
+           "quoted"
+           ]
+       },
+   "results": {
+       "bindings": [
+               {
+                   "x" : { "type": "bnode", "value": "r1" },
+
+                   "name" : {  "type": "literal", "value": "Alice" } ,
 
                    "quoted" : {
                      "type": "triple",
                      "value": {
                         "subject": {
                            "type": "uri",
-                           "value" "http://example.org/bob"
+                           "value": "http://example.org/alice"
                         },
                         "predicate": {
                            "type": "uri",
-                           "value" "http://example.org/name"
+                           "value": "http://example.org/name"
                         },
                         "object": {
                            "type": "literal",
-                           "value" "Bob",
+                           "value": "Alice",
+                           "datatype": "http://www.w3.org/2001/XMLSchema#string"
+                        }
+                     }
+                   }
+               },
+               {
+                   "x" : { "type": "bnode", "value": "r2" },
+                   
+                   "name" : { "type": "literal", "value": "Bob", "xml:lang": "en" },
+
+                   "quoted" : {
+                     "type": "triple",
+                     "value": {
+                        "subject": {
+                           "type": "uri",
+                           "value": "http://example.org/bob"
+                        },
+                        "predicate": {
+                           "type": "uri",
+                           "value": "http://example.org/name"
+                        },
+                        "object": {
+                           "type": "literal",
+                           "value": "Bob",
                            "datatype": "http://www.w3.org/2001/XMLSchema#string"
                         }
                      }
@@ -623,6 +654,7 @@ span.cancast:hover { background-color: #ffa;
            ]
        }
 }</pre>
+      </section>
     </section>
     <section id="content-type">
       <h2>Internet Media Type, File Extension and Macintosh File Type</h2>


### PR DESCRIPTION
This PR allows quoted triples to be expressed in SPARQL/JSON according to how it was defined in the CG report: https://w3c.github.io/rdf-star/cg-spec/editors_draft.html#sparql-star-query-results-json-format

Note that the modified example near the bottom depends on the SPARQLXML example also to be updated, so that they remain in-sync. (perhaps we want to wait with merging this PR for that reason until the SPARQL/XML side has also been updated) See https://github.com/w3c/sparql-results-xml/pull/19


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-json/pull/19.html" title="Last updated on Apr 21, 2023, 9:42 AM UTC (7a322a4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-json/19/745910d...7a322a4.html" title="Last updated on Apr 21, 2023, 9:42 AM UTC (7a322a4)">Diff</a>