### PR TITLE
Provide old fragment name

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -622,7 +622,7 @@ span.cancast:hover { background-color: #ffa;
 }</pre>
       </section>
     </section>
-    <section id="media-type">
+    <section id="media-type"><div id="mime"></div>
       <h2>Internet Media Type, File Extension and Macintosh File Type</h2>
       <p>The Internet Media Type (formerly known as MIME Type) for the SPARQL Query Results JSON Format is "application/sparql-results+json".</p>
       <p>It is recommended that SPARQL Query Results JSON Format files have the extension ".srj" (all lowercase) on all platforms.</p>


### PR DESCRIPTION
This applies the suggestion https://github.com/w3c/sparql-results-json/pull/29#discussion_r1258651325.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-json/pull/31.html" title="Last updated on Jul 27, 2023, 4:55 PM UTC (c95bd01)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-json/31/47e9c9c...c95bd01.html" title="Last updated on Jul 27, 2023, 4:55 PM UTC (c95bd01)">Diff</a>