### PR TITLE
Support directional language-tagged strings, Closes #32

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -517,6 +517,7 @@ span.cancast:hover { background-color: #ffa;
           <p>The blank node label is scoped to the results object. That is, two blank nodes with the same label in a single SPARQL Results JSON object are the same blank node. This is not an
           indication of any internal system identifier the SPARQL processor may use. Use of the same label in another SPARQL Results JSON object does not imply it is the same blank node.</p>
           <p>The subject, predicate, and object of a quoted triple are encoded using the same format, recursively.</p>
+          <p class="note">The "xml:lang" and "its:dir" keys resemble usage of XML namespaces due to alignment with the [[[SPARQL12-RESULTS-XML]]] specification, but namespaces do not exist JSON, which means that these keys should be used as-is.</p>
         </section>
       </section>
     </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -517,7 +517,7 @@ span.cancast:hover { background-color: #ffa;
           <p>The blank node label is scoped to the results object. That is, two blank nodes with the same label in a single SPARQL Results JSON object are the same blank node. This is not an
           indication of any internal system identifier the SPARQL processor may use. Use of the same label in another SPARQL Results JSON object does not imply it is the same blank node.</p>
           <p>The subject, predicate, and object of a quoted triple are encoded using the same format, recursively.</p>
-          <p class="note">The "`xml:lang`" and "`its:dir`" keys resemble terms in XML namespaces due to alignment with the [[[SPARQL12-RESULTS-XML]]] specification, but such namespaces do not exist in JSON, which means that these keys are to be used "as is".</p>
+          <p class="note">The <code>xml:lang</code> and <code>its:dir</code> keys resemble terms in XML namespaces due to alignment with the [[[SPARQL12-RESULTS-XML]]] specification, but such namespaces do not exist in JSON, which means that these keys are to be used "as is".</p>
         </section>
       </section>
     </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -517,7 +517,7 @@ span.cancast:hover { background-color: #ffa;
           <p>The blank node label is scoped to the results object. That is, two blank nodes with the same label in a single SPARQL Results JSON object are the same blank node. This is not an
           indication of any internal system identifier the SPARQL processor may use. Use of the same label in another SPARQL Results JSON object does not imply it is the same blank node.</p>
           <p>The subject, predicate, and object of a quoted triple are encoded using the same format, recursively.</p>
-          <p class="note">The "xml:lang" and "its:dir" keys resemble usage of XML namespaces due to alignment with the [[[SPARQL12-RESULTS-XML]]] specification, but namespaces do not exist JSON, which means that these keys should be used as-is.</p>
+          <p class="note">The "`xml:lang`" and "`its:dir`" keys resemble terms in XML namespaces due to alignment with the [[[SPARQL12-RESULTS-XML]]] specification, but such namespaces do not exist in JSON, which means that these keys are to be used "as is".</p>
         </section>
       </section>
     </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -493,8 +493,12 @@ span.cancast:hover { background-color: #ffa;
                 <td><code>{"type": "literal","value": "<em><b>S</b></em>"}</code></td>
               </tr>
               <tr>
-                <td>Literal <em><b>S</b></em> with language tag <em><b>L</b></em></td>
+                <td>Literal <em><b>S</b></em> with language tag <em><b>L</b></em> without base direction</td>
                 <td><code>{ "type": "literal", "value": "<em><b>S</b></em>", "xml:lang": "<em><b>L</b></em>"}</code></td>
+              </tr>
+              <tr>
+                <td>Literal <em><b>S</b></em> with language tag <em><b>L</b></em> with base direction <em><b>L</b></em></td>
+                <td><code>{ "type": "literal", "value": "<em><b>S</b></em>", "xml:lang": "<em><b>L</b></em>", "its:dir": "<em><b>B</b></em>"}</code></td>
               </tr>
               <tr>
                 <td>Literal <em><b>S</b></em> with datatype IRI <em><b>D</b></em></td>


### PR DESCRIPTION
`"its:dir"` was chosen as key to be aligned with `"xml:lang"` following https://www.w3.org/TR/2007/REC-its-20070403/#att.dir


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-json/pull/33.html" title="Last updated on Nov 30, 2023, 5:26 PM UTC (e0c89df)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/sparql-results-json/33/70242f3...e0c89df.html" title="Last updated on Nov 30, 2023, 5:26 PM UTC (e0c89df)">Diff</a>