### PR TITLE
Fixes sec 4.2.2 quoted triples encoding

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -510,7 +510,7 @@ span.cancast:hover { background-color: #ffa;
               </tr>
               <tr>
                 <td>Quoted triple, with subject <em><b>S</b></em>, predicate <em><b>P</b></em>, and object <em><b>O</b></em></td>
-                <td><code>{"type": "triple", "subject": "<em><b>S</b></em>", "predicate": "<em><b>P</b></em>", "object": "<em><b>O</b></em>"}</code></td>
+                <td><code>{"type": "triple", "value": {"subject": "<em><b>S</b></em>", "predicate": "<em><b>P</b></em>", "object": "<em><b>O</b></em>"}}</code></td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
According to the CG report and the examples in the current spec, the `subject`, `predicate` and `object` keys should be in the `value` key


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 502 Bad Gateway :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Feb 5, 2024, 8:12 AM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [Spec Generator](https://www.w3.org/2015/labs/) - Spec Generator is the web service used to build specs that rely on ReSpec.

:link: [Related URL]([object Object])

```
error code: 502
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/sparql-results-json%2335.)._
</details>
